### PR TITLE
HybridTechDetection with wappalyzer and tech templates.

### DIFF
--- a/pkg/protocols/common/automaticscan/automaticscan.go
+++ b/pkg/protocols/common/automaticscan/automaticscan.go
@@ -1,28 +1,31 @@
 package automaticscan
 
 import (
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/corpix/uarand"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
 	"github.com/projectdiscovery/nuclei/v3/pkg/core"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/writer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	httputil "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/http"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/retryablehttp-go"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 	wappalyzer "github.com/projectdiscovery/wappalyzergo"
 	"gopkg.in/yaml.v2"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 )
 
 // Service is a service for automatic scan execution
@@ -38,6 +41,7 @@ type Service struct {
 	results            bool
 	allTemplates       []string
 	technologyMappings map[string]string
+	techTemplates      []*templates.Template
 }
 
 // Options contains configuration options for automatic scan service
@@ -84,6 +88,13 @@ func New(opts Options) (*Service, error) {
 		}
 		allTemplates = append(allTemplates, templates...)
 	}
+	tagTemplates := opts.Store.LoadTemplatesWithTags(allTemplates, []string{"tech"})
+	if len(tagTemplates) == 0 {
+		return nil, errors.New("could not find any templates with tech tag")
+	}
+	tagTemplates, _ = templates.ClusterTemplates(tagTemplates, opts.ExecuterOpts)
+	gologger.Info().Msgf("Loaded %d cluster templates from the tech tag.\n", len(tagTemplates))
+
 	childExecuter := opts.Engine.ChildExecuter()
 
 	httpclient, err := httpclientpool.Get(opts.ExecuterOpts.Options, &httpclientpool.Configuration{
@@ -105,6 +116,7 @@ func New(opts Options) (*Service, error) {
 		childExecuter:      childExecuter,
 		httpclient:         httpclient,
 		technologyMappings: mappingData,
+		techTemplates:      tagTemplates,
 	}, nil
 }
 
@@ -119,7 +131,7 @@ func (s *Service) Close() bool {
 
 // Execute performs the execution of automatic scan on provided input
 func (s *Service) Execute() {
-	if err := s.executeWappalyzerTechDetection(); err != nil {
+	if err := s.executeHybridTechDetection(); err != nil {
 		gologger.Error().Msgf("Could not execute wappalyzer based detection: %s", err)
 	}
 }
@@ -130,7 +142,7 @@ const maxDefaultBody = 2 * 1024 * 1024
 // technologies detection on inputs which returns tech.
 //
 // The returned tags are then used for further execution.
-func (s *Service) executeWappalyzerTechDetection() error {
+func (s *Service) executeHybridTechDetection() error {
 	gologger.Info().Msgf("Executing wappalyzer based tech detection on input urls")
 
 	// Iterate through each target making http request and identifying fingerprints
@@ -142,7 +154,7 @@ func (s *Service) executeWappalyzerTechDetection() error {
 		go func(input *contextargs.MetaInput) {
 			defer inputPool.WaitGroup.Done()
 
-			s.processWappalyzerInputPair(input)
+			s.processHybridInputPair(input)
 		}(value)
 		return true
 	})
@@ -150,10 +162,10 @@ func (s *Service) executeWappalyzerTechDetection() error {
 	return nil
 }
 
-func (s *Service) processWappalyzerInputPair(input *contextargs.MetaInput) {
+func (s *Service) getTechUseWappalyzer(input *contextargs.MetaInput) []string {
 	req, err := retryablehttp.NewRequest(http.MethodGet, input.Input, nil)
 	if err != nil {
-		return
+		return nil
 	}
 	req.Header.Set("User-Agent", uarand.GetRandom())
 
@@ -162,13 +174,13 @@ func (s *Service) processWappalyzerInputPair(input *contextargs.MetaInput) {
 		if resp != nil {
 			resp.Body.Close()
 		}
-		return
+		return nil
 	}
 	reader := io.LimitReader(resp.Body, maxDefaultBody)
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		resp.Body.Close()
-		return
+		return nil
 	}
 	resp.Body.Close()
 
@@ -199,16 +211,105 @@ func (s *Service) processWappalyzerInputPair(input *contextargs.MetaInput) {
 			items = append(items, strings.ToLower(k))
 		}
 	}
-	if len(items) == 0 {
+	return sliceutil.Dedupe(items)
+}
+
+func (s *Service) getTechUseDetectTemplate(input *contextargs.MetaInput) ([]string, []string) {
+	ctxArgs := contextargs.New()
+	ctxArgs.MetaInput = input
+	inputPool := s.engine.WorkPool().InputPool(types.HTTPProtocol)
+
+	resultsChan := make(chan []*output.ResultEvent)
+	resultsSlice := make([][]*output.ResultEvent, 0)
+
+	successTags := make([]string, 0)
+	successTemplateName := make([]string, 0)
+	var resultsWaitGroup sync.WaitGroup
+	resultsWaitGroup.Add(1)
+	go func() {
+		defer resultsWaitGroup.Done()
+		for result := range resultsChan {
+			resultsSlice = append(resultsSlice, result)
+		}
+	}()
+	for _, t := range s.techTemplates {
+		inputPool.WaitGroup.Add()
+		go func(template *templates.Template) {
+			defer inputPool.WaitGroup.Done()
+			ctx := scan.NewScanContext(ctxArgs)
+			ctx.OnResult = func(event *output.InternalWrappedEvent) {
+				if event == nil {
+					// something went wrong
+					return
+				}
+				// If no results were found, and also interactsh is not being used
+				// in that case we can skip it, otherwise we've to show failure in
+				// case of matcher-status flag.
+				if event.HasOperatorResult() || event.UsesInteractsh {
+					writer.WriteResult(event, s.opts.Output, s.opts.Progress, s.opts.IssuesClient)
+				}
+			}
+			results, err := template.Executer.ExecuteWithResults(ctx)
+			if err != nil {
+				gologger.Error().Msgf("error executing template: %s with error: %s\n", template.Info.Name, err)
+				return
+			}
+			if len(results) > 0 {
+				resultsChan <- results
+			}
+		}(t)
+	}
+	inputPool.WaitGroup.Wait()
+	close(resultsChan)
+	resultsWaitGroup.Wait()
+	for _, results := range resultsSlice {
+		for _, r := range results {
+			successTags = append(successTags, r.Info.Tags.ToSlice()...)
+			// Collect the technologies specified in the matcher.name.
+			if len(r.MatcherName) != 0 {
+				successTags = append(successTags, r.MatcherName)
+			}
+			successTemplateName = append(successTemplateName, r.TemplateID)
+		}
+	}
+
+	return sliceutil.Dedupe(successTags), successTemplateName
+}
+
+func (s *Service) processHybridInputPair(input *contextargs.MetaInput) {
+	successTags := make([]string, 0)
+	tagsUseWappalyzer := s.getTechUseWappalyzer(input)
+	tagsUseDetectTemplate, successTemplateName := s.getTechUseDetectTemplate(input)
+	gologger.Info().Msgf("Executing Wappalyzer based tech detection get (%v) for host %s", strings.Join(tagsUseWappalyzer, ", "), input)
+	gologger.Info().Msgf("Executing Template based tech detection get (%v) for host %s", strings.Join(tagsUseDetectTemplate, ", "), input)
+	successTags = append(successTags, tagsUseWappalyzer...)
+	successTags = append(successTags, tagsUseDetectTemplate...)
+	successTags = append(successTags, s.opts.Options.Tags...)
+	uniqueTags := sliceutil.Dedupe(successTags)
+
+	var tags []string
+	// delete tech tag
+	for _, tag := range uniqueTags {
+		if tag == "tech" || tag == "waf" || tag == "favicon" {
+			continue
+		}
+		tags = append(tags, tag)
+	}
+	if len(tags) == 0 {
 		return
 	}
-	// Add tags as addition to -as for comprehensive scans. Ref: nuclei/issues/3348
-	items = append(items, s.opts.Options.Tags...)
-	uniqueTags := sliceutil.Dedupe(items)
-
-	templatesList := s.store.LoadTemplatesWithTags(s.allTemplates, uniqueTags)
-	gologger.Info().Msgf("Executing tags (%v) for host %s (%d templates)", strings.Join(uniqueTags, ","), input, len(templatesList))
+	templatesList := s.store.LoadTemplatesWithTags(s.allTemplates, tags)
+	finallyTemplates := make([]*templates.Template, 0)
+	// delete templates which are already executed
 	for _, t := range templatesList {
+		if sliceutil.Contains(successTemplateName, t.ID) {
+			continue
+		}
+		finallyTemplates = append(finallyTemplates, t)
+	}
+	gologger.Info().Msgf("Executing tags (%v) for host %s (%d templates)", strings.Join(tags, ", "), input, len(templatesList))
+	finallyTemplates, _ = templates.ClusterTemplates(finallyTemplates, s.opts)
+	for _, t := range finallyTemplates {
 		s.opts.Progress.AddToTotal(int64(t.Executer.Requests()))
 
 		if s.opts.Options.VerboseVerbose {


### PR DESCRIPTION
## Proposed changes

implement hybrid tech detection

This commit introduces the implementation of hybrid technology detection in the automaticscan package. The hybrid detection utilizes both Wappalyzer and Nuclei templates to identify technologies used by a target.

- Keep Wappalyzer-based technology detection using fingerprints.
- Add tech tag templates for technology detection.
